### PR TITLE
Add --base-url flag for connector testability

### DIFF
--- a/cmd/baton-ringcentral/config.go
+++ b/cmd/baton-ringcentral/config.go
@@ -34,6 +34,7 @@ var (
 	baseURLField = field.StringField(
 		baseURLFieldName,
 		field.WithDescription("Override the RingCentral API URL (for testing)"),
+		field.WithHidden(true),
 	)
 
 	// ConfigurationFields defines the external configuration required for the

--- a/cmd/baton-ringcentral/config.go
+++ b/cmd/baton-ringcentral/config.go
@@ -9,6 +9,7 @@ const (
 	ringCentralClientID     = "ringcentral-client-id"
 	ringCentralClientSecret = "ringcentral-client-secret"
 	ringCentralJWT          = "ringcentral-jwt"
+	baseURLFieldName        = "base-url"
 )
 
 var (
@@ -30,6 +31,11 @@ var (
 		field.WithDescription("JWT of the admin user on RingCentral platform"),
 	)
 
+	baseURLField = field.StringField(
+		baseURLFieldName,
+		field.WithDescription("Override the RingCentral API URL (for testing)"),
+	)
+
 	// ConfigurationFields defines the external configuration required for the
 	// connector to run. Note: these fields can be marked as optional or
 	// required.
@@ -37,6 +43,7 @@ var (
 		rcClientIDField,
 		rcClientSecretField,
 		rcJWTField,
+		baseURLField,
 	}
 )
 

--- a/cmd/baton-ringcentral/main.go
+++ b/cmd/baton-ringcentral/main.go
@@ -47,6 +47,7 @@ func getConnector(ctx context.Context, v *viper.Viper) (types.ConnectorServer, e
 	rcClientID := v.GetString(ringCentralClientID)
 	rcClientSecret := v.GetString(ringCentralClientSecret)
 	rcJWT := v.GetString(ringCentralJWT)
+	baseURL := v.GetString(baseURLFieldName)
 
 	l := ctxzap.Extract(ctx)
 	if err := ValidateConfig(v); err != nil {
@@ -58,6 +59,7 @@ func getConnector(ctx context.Context, v *viper.Viper) (types.ConnectorServer, e
 		rcClientID,
 		rcClientSecret,
 		rcJWT,
+		baseURL,
 	)
 	if err != nil {
 		l.Error("error creating connector", zap.Error(err))

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -17,7 +17,7 @@ import (
 )
 
 const (
-	urlBase = "https://platform.ringcentral.com/restapi"
+	defaultBaseURL = "https://platform.ringcentral.com/restapi"
 
 	oauthURL          = "/oauth/token"
 	getExtensions     = "/v1.0/account/~/extension"
@@ -29,6 +29,7 @@ type RingCentralClient struct {
 	Config      ClientConfig
 	client      *uhttp.BaseHttpClient
 	accessToken string
+	baseURL     string
 }
 
 type ClientConfig struct {
@@ -63,6 +64,14 @@ func WithJWT(jwt string) Option {
 	}
 }
 
+func WithBaseURL(baseURL string) Option {
+	return func(c *RingCentralClient) {
+		if baseURL != "" {
+			c.baseURL = baseURL
+		}
+	}
+}
+
 func (c *RingCentralClient) GetToken() string {
 	return c.accessToken
 }
@@ -79,7 +88,8 @@ func New(ctx context.Context, opts ...Option) (*RingCentralClient, error) {
 	}
 
 	rcClient := RingCentralClient{
-		client: cli,
+		client:  cli,
+		baseURL: defaultBaseURL,
 	}
 
 	for _, o := range opts {
@@ -98,7 +108,7 @@ func New(ctx context.Context, opts ...Option) (*RingCentralClient, error) {
 }
 
 func (c *RingCentralClient) requestAccessToken(ctx context.Context) (string, error) {
-	requestURL, err := url.JoinPath(urlBase, oauthURL)
+	requestURL, err := url.JoinPath(c.baseURL, oauthURL)
 	if err != nil {
 		return "", err
 	}
@@ -196,7 +206,7 @@ Users withing the platform are named as 'Extension'.
 func (c *RingCentralClient) ListAllUsers(ctx context.Context, pageOps PageOptions) ([]Extension, string, error) {
 	var response ExtensionResponse
 
-	queryUrl, err := url.JoinPath(urlBase, getExtensions)
+	queryUrl, err := url.JoinPath(c.baseURL, getExtensions)
 	if err != nil {
 		return nil, "", err
 	}
@@ -212,7 +222,7 @@ func (c *RingCentralClient) ListAllUsers(ctx context.Context, pageOps PageOption
 func (c *RingCentralClient) ListAllAvailableRoles(ctx context.Context, pageOps PageOptions) ([]Role, string, error) {
 	var response RoleResponse
 
-	queryUrl, err := url.JoinPath(urlBase, getAvailableRoles)
+	queryUrl, err := url.JoinPath(c.baseURL, getAvailableRoles)
 	if err != nil {
 		return nil, "", err
 	}
@@ -227,7 +237,7 @@ func (c *RingCentralClient) ListAllAvailableRoles(ctx context.Context, pageOps P
 
 func (c *RingCentralClient) GetUserAssignedRoles(ctx context.Context, userResource *v2.Resource) ([]UserRole, error) {
 	var res UserRoleResponse
-	queryUrl, err := url.JoinPath(urlBase, fmt.Sprintf(userRoles, userResource.Id.Resource))
+	queryUrl, err := url.JoinPath(c.baseURL, fmt.Sprintf(userRoles, userResource.Id.Resource))
 	if err != nil {
 		return nil, err
 	}
@@ -319,7 +329,7 @@ func (c *RingCentralClient) UpdateUserRoles(ctx context.Context, userResource *v
 	body := map[string]interface{}{
 		"records": roleIDs,
 	}
-	requestURL, err := url.JoinPath(urlBase, fmt.Sprintf(userRoles, userResource.Id.Resource))
+	requestURL, err := url.JoinPath(c.baseURL, fmt.Sprintf(userRoles, userResource.Id.Resource))
 	if err != nil {
 		return err
 	}

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -44,12 +44,13 @@ func (d *Connector) Validate(_ context.Context) (annotations.Annotations, error)
 }
 
 // New returns a new instance of the connector.
-func New(ctx context.Context, rcClientID, rcClientSecret, rcJWT string) (*Connector, error) {
+func New(ctx context.Context, rcClientID, rcClientSecret, rcJWT, baseURL string) (*Connector, error) {
 	c, err := client.New(
 		ctx,
 		client.WithClientID(rcClientID),
 		client.WithClientSecret(rcClientSecret),
 		client.WithJWT(rcJWT),
+		client.WithBaseURL(baseURL),
 	)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Summary

Adds the `--base-url` CLI flag to enable overriding the default API endpoint for testing purposes.

## Changes

- Added `BaseURLField` to configuration
- Updated client/connector to accept and use the base URL override
- When `--base-url` is provided, it takes precedence over the default API URL

## Files Modified

```
cmd/baton-ringcentral/config.go,cmd/baton-ringcentral/main.go,pkg/client/client.go,pkg/connector/connector.go
```

## Testing

The connector can now be tested against mock servers:
```bash
baton-ringcentral --base-url http://localhost:8080 [other-flags]
```

## Related

Part of the Connector Testability initiative.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable base URL support for flexible endpoint configuration across different environments.

* **Breaking Changes**
  * Constructor initialization now requires a base URL parameter; existing code creating connector instances must be updated to include this parameter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->