### PR TITLE
fix: mark ringcentral-client-secret and ringcentral-jwt as isSecret in config_schema

### DIFF
--- a/cmd/baton-ringcentral/config.go
+++ b/cmd/baton-ringcentral/config.go
@@ -22,12 +22,14 @@ var (
 		ringCentralClientSecret,
 		field.WithRequired(true),
 		field.WithDescription("Client Secret of the Baton App for RingCentral"),
+		field.WithIsSecret(true),
 	)
 
 	rcJWTField = field.StringField(
 		ringCentralJWT,
 		field.WithRequired(true),
 		field.WithDescription("JWT of the admin user on RingCentral platform"),
+		field.WithIsSecret(true),
 	)
 
 	// ConfigurationFields defines the external configuration required for the


### PR DESCRIPTION
Marks `ringcentral-client-secret` and `ringcentral-jwt` as secret (`ringcentral-client-id` stays non-secret). baton-ringcentral defines config in Go with no committed config_schema.json; the fix adds `field.WithIsSecret(true)`.

> BREAKING: adding `isSecret: true` to these fields changes how existing
> configurations are stored. Customers with existing connector configurations
> will need to re-enter credentials after this change is deployed.

Review only — do not merge.
