### PR TITLE
docs: update description and fix connector setup instructions

### DIFF
--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -1,8 +1,8 @@
 ---
 title: Set up a RingCentral connector
 og:title: Set up a RingCentral connector - C1 docs
-og:description: Integrate your RingCentral instance with C1 to run user access reviews, enable just-in-time access requests, and easily provision and deprovision role access.
-description: C1 provides identity governance and just-in-time provisioning for RingCentral. Integrate your RingCentral instance with C1 to run user access reviews (UARs), enable just-in-time access requests, and provision or deprovision role assignments.
+og:description: Integrate your RingCentral instance with C1 to run user access reviews, enable just-in-time access requests, and easily provision and deprovision access.
+description: C1 provides identity governance and just-in-time provisioning for RingCentral. Integrate your RingCentral instance with C1 to run user access reviews (UARs), and enable just-in-time access requests.
 sidebarTitle: RingCentral
 ---
 
@@ -31,7 +31,7 @@ A user with access to the RingCentral Developer Console must perform this task.
 
 <Steps>
 <Step>
-Log into the [RingCentral Developer Console](https://developers.ringcentral.com/my-account.html#/applications).
+Log into the RingCentral Developer Console.
 </Step>
 <Step>
 Navigate to **Console** > **Apps** and click **Create App**. 
@@ -77,7 +77,7 @@ Select the **Only specific apps of my choice** option and enter the client ID of
 Click **Create**. Carefully copy and save the JWT token. 
 </Step>
 </Steps>
-**That's it!** Next, move on to the connector configuration instructions. 
+**Done.** Next, move on to the connector configuration instructions. 
 
 ## Configure the RingCentral connector
 
@@ -135,7 +135,7 @@ Click **Save**.
 The connector's label changes to **Syncing**, followed by **Connected**. You can view the logs to ensure that information is syncing.
 </Step>
 </Steps>
-**That's it!** Your RingCentral connector is now pulling access data into C1.
+**Done.** Your RingCentral connector is now pulling access data into C1.
 </Tab>
 <Tab title="Self-hosted">
 **Follow these instructions to use the RingCentral connector, hosted and run in your own environment.**
@@ -255,6 +255,6 @@ Check that the connector data uploaded correctly. In C1, click **Apps**. On the 
 </Steps>
 
 
-**That's it!** Your RingCentral connector is now pulling access data into C1.
+**Done.** Your RingCentral connector is now pulling access data into C1.
 </Tab>
 </Tabs>


### PR DESCRIPTION
Updates the connector description to remove "role" from the provisioning language, removes a hardcoded link from the setup instructions, and aligns wording with the published docs site.